### PR TITLE
Set indent to 0 when moving block to- or in the hand

### DIFF
--- a/app/src/communication/CommunicationHandler.js
+++ b/app/src/communication/CommunicationHandler.js
@@ -86,7 +86,7 @@ class CommunicationHandler extends Component {
    * @param {*} webrtc : : Keeps information about the room
    * @returns
    */
-  join = (webrtc) => webrtc.joinRoom('cpp-room6');
+  join = (webrtc) => webrtc.joinRoom('cpp-room7');
 
   /**
    * Called when a new peer is added to the room

--- a/app/src/components/HandList/HandList.jsx
+++ b/app/src/components/HandList/HandList.jsx
@@ -67,10 +67,11 @@ function HandList({ player, draggable }) {
    * @param {*} atIndex     the new index of the block
    */
   const swapBlockPositionInList = (blockObj, atIndex) => {
+    const updatedBlock = { ...blockObj.block, indent: 0 }; // set indent to 0
     const updatedBlocks = update(blocks, {
       $splice: [
         [blockObj.index, 1],
-        [atIndex, 0, blockObj.block],
+        [atIndex, 0, updatedBlock],
       ],
     });
 
@@ -90,9 +91,10 @@ function HandList({ player, draggable }) {
     // players cannot move their own blocks to another player's hand
     // a player can only move their own block to their own hand from solution field
     if (movedBlock !== undefined && movedBlock.player === player) {
+      const updatedBlock = { ...movedBlock, indent: 0 }; // set indent to 0
       const updatedBlocks = [
         ...blocks.slice(0, atIndex),
-        movedBlock,
+        updatedBlock,
         ...blocks.slice(atIndex),
       ];
 


### PR DESCRIPTION
Fixes bug where if a block was indented in the solution field and was moved into the hand the indent was maintained. 