### PR TITLE
Show selected codeblocks

### DIFF
--- a/app/src/components/game/CodeLine/CodeLine.jsx
+++ b/app/src/components/game/CodeLine/CodeLine.jsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import { COLORS } from '../../../utils/constants';
 import CodeBlock from '../CodeBlock/CodeBlock';
 import { useDrop } from 'react-dnd';
 import { ItemTypes } from '../../../utils/itemtypes';
 import './CodeLine.css';
-import { useRef } from 'react';
 import { OFFSET } from '../../../utils/constants';
 import PropTypes from 'prop-types';
 
@@ -17,12 +16,16 @@ import PropTypes from 'prop-types';
  * @param {object} block contains information about a code block
  * @param {number} index the index of this code line
  * @param {Function} moveBlock callback function to move the block
+ * @param {Function} handleDoubleclick callback function to move the block with click event
+*  @param {Function} unselectOnHover callback to set the selected block to be null
  * @param {number} maxIndent  the max indent a block can have
  * @param {boolean} draggable whether the player shall be able to drag the block or not
+ * @param {int} isSelected wheter or not this codeline in was selected
  * @returns CodeLine component
  */
-function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubbleClick }) {
+function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubbleClick, isSelected}) {
   const blockRef = useRef(null); // reference to get the position of the DOM element
+  const [border, setBorder] = useState('none');
   const MAX_INDENT = maxIndent;
   const [, lineDrop] = useDrop(
     () => ({
@@ -48,10 +51,23 @@ function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubble
     [block, moveBlock]
   );
 
+  /**
+   * Sets a border on selected codelines.
+   * For visual aid.
+   */
+  useEffect(() => {
+    if(isSelected && isSelected.id === block.id){
+      setBorder('solid #c2c2c2 0.1em');
+    }
+    else{
+      setBorder('none');
+    }
+  }, [isSelected])
+
   return (
     <li
       data-testid='codeline'
-      style={{ background: COLORS.codeline }}
+      style={{ background: COLORS.codeline, border: border }}
       ref={lineDrop}
       key={draggable}
     >
@@ -61,10 +77,10 @@ function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubble
         id={`blockref-${block.id}`}
         data-testid={`blockref-${block.id}`}
         ref={blockRef}
-        style={{ marginLeft: `${block.indent * OFFSET}px` }}
+        style={{ marginLeft: `${block.indent * OFFSET}px`}}
         onClick={(e) => handleDoubbleClick(e, block, draggable, index)}
       >
-        <CodeBlock {...block} index={index} draggable={draggable} />
+        <CodeBlock {...block} index={index} draggable={draggable}/>
       </div>
     </li>
   );
@@ -74,6 +90,7 @@ CodeLine.propTypes = {
   block: PropTypes.object,
   index: PropTypes.number,
   moveBlock: PropTypes.func,
+  unSelectOnHover: PropTypes.func,
   maxIndent: PropTypes.number,
   draggable: PropTypes.bool,
 };

--- a/app/src/components/game/CodeLine/CodeLine.jsx
+++ b/app/src/components/game/CodeLine/CodeLine.jsx
@@ -20,10 +20,10 @@ import PropTypes from 'prop-types';
 *  @param {Function} unselectOnHover callback to set the selected block to be null
  * @param {number} maxIndent  the max indent a block can have
  * @param {boolean} draggable whether the player shall be able to drag the block or not
- * @param {int} isSelected wheter or not this codeline in was selected
+ * @param {int} selectedCodeline information about the currently selected codeline. This could be this codeline.
  * @returns CodeLine component
  */
-function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubbleClick, isSelected}) {
+function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubbleClick, selectedCodeline}) {
   const blockRef = useRef(null); // reference to get the position of the DOM element
   const [border, setBorder] = useState('none');
   const MAX_INDENT = maxIndent;
@@ -56,13 +56,13 @@ function CodeLine({ block, index, moveBlock, maxIndent, draggable, handleDoubble
    * For visual aid.
    */
   useEffect(() => {
-    if(isSelected && isSelected.id === block.id){
+    if(selectedCodeline && selectedCodeline.id === block.id){
       setBorder('solid #c2c2c2 0.1em');
     }
     else{
       setBorder('none');
     }
-  }, [isSelected])
+  }, [selectedCodeline])
 
   return (
     <li

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -71,14 +71,14 @@ function SolutionField({}) {
    */
   const handleKeyDown = useCallback(e=> {
     e.preventDefault();     // do not target adress bar
-      if(selectedCodeline != null && e.keyCode != null){
-        if (e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {      // TAB
-          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
-          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
-        }
-        else if(e.keyCode === KEYBOARD_EVENT.BACKSPACE && selectedCodeline.indent > 0){      // BACKSPACE
+      if(selectedCodeline != null && e.keyCode != null){               // SHIFT TAB OR BACKSPACE
+        if((e.shiftKey && e.keyCode == KEYBOARD_EVENT.TAB  && selectedCodeline.indent > 0) || (e.keyCode === KEYBOARD_EVENT.BACKSPACE  && selectedCodeline.indent > 0)) { 
           setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent-1}))
           moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent -1, false);
+        }
+        else if (!e.shiftKey && e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {      // TAB
+          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
+          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
         }
     } 
   },);

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -28,7 +28,7 @@ function SolutionField({}) {
   const blocks = useSelector((state) => state.solutionField);
   const players = useSelector((state) => state.players);
   const dispatch = useDispatch();
-  const [selectedBlock, setSelectedBlock] = useState(null);     // block selected for the next keyDown event
+  const [selectedCodeline, setSelectedCodeline] = useState(null);     // block selected for the next keyDown event
 
   // finds the block, it's index and indent based on id
   const findBlock = useCallback(
@@ -49,7 +49,7 @@ function SolutionField({}) {
   const moveBlock = useCallback(
     (id, atIndex, atIndent = 0, mouseEvent = true) => {
       if(mouseEvent){
-        setSelectedBlock(null);  // reset selected codeblocks
+        setSelectedCodeline(null);  // reset selected codeblocks
       }
       // get block if it exists in solutionfield
       const block = findBlock(id);
@@ -71,14 +71,14 @@ function SolutionField({}) {
    */
   const handleKeyDown = useCallback(e=> {
     e.preventDefault();     // do not target adress bar
-      if(selectedBlock != null && e.keyCode != null){
-        if (e.keyCode === KEYBOARD_EVENT.TAB && selectedBlock.indent < MAX_INDENT) {      // TAB
-          setSelectedBlock((selectedBlock) => ({...selectedBlock, indent: selectedBlock.indent+1}))
-          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent +1, false);
+      if(selectedCodeline != null && e.keyCode != null){
+        if (e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {      // TAB
+          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
+          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
         }
-        else if(e.keyCode === KEYBOARD_EVENT.BACKSPACE && selectedBlock.indent > 0){      // BACKSPACE
-          setSelectedBlock((selectedBlock) => ({...selectedBlock, indent: selectedBlock.indent-1}))
-          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent -1, false);
+        else if(e.keyCode === KEYBOARD_EVENT.BACKSPACE && selectedCodeline.indent > 0){      // BACKSPACE
+          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent-1}))
+          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent -1, false);
         }
     } 
   },);
@@ -171,7 +171,7 @@ function SolutionField({}) {
    * @param {*} draggable : wheter or not the player has permission to perform this action
    */
   const handleDoubbleClick = (e, movedBlock, draggable, index) => {
-    setSelectedBlock(movedBlock);
+    setSelectedCodeline(movedBlock);
 
     if(movedBlock != null && draggable){
     
@@ -203,7 +203,7 @@ function SolutionField({}) {
               draggable={true}
               key={`line-${index}`}
               handleDoubbleClick = {handleDoubbleClick}
-              isSelected = {selectedBlock}
+              selectedCodeline = {selectedCodeline}
             />
           );
         })}

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -47,7 +47,10 @@ function SolutionField({}) {
 
   // move the block within the field or to a hand list
   const moveBlock = useCallback(
-    (id, atIndex, atIndent = 0) => {
+    (id, atIndex, atIndent = 0, mouseEvent = true) => {
+      if(mouseEvent){
+        setSelectedBlock(null);  // reset selected codeblocks
+      }
       // get block if it exists in solutionfield
       const block = findBlock(id);
       if (block === undefined) {
@@ -67,15 +70,15 @@ function SolutionField({}) {
    * Tab and bacskpace changes indenting.
    */
   const handleKeyDown = useCallback(e=> {
+    e.preventDefault();     // do not target adress bar
       if(selectedBlock != null && e.keyCode != null){
- 
         if (e.keyCode === KEYBOARD_EVENT.TAB && selectedBlock.indent < MAX_INDENT) {      // TAB
-          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent +1);
           setSelectedBlock((selectedBlock) => ({...selectedBlock, indent: selectedBlock.indent+1}))
+          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent +1, false);
         }
         else if(e.keyCode === KEYBOARD_EVENT.BACKSPACE && selectedBlock.indent > 0){      // BACKSPACE
-          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent -1);
           setSelectedBlock((selectedBlock) => ({...selectedBlock, indent: selectedBlock.indent-1}))
+          moveBlock(selectedBlock.id, selectedBlock.index, selectedBlock.indent -1, false);
         }
     } 
   },);
@@ -168,22 +171,22 @@ function SolutionField({}) {
    * @param {*} draggable : wheter or not the player has permission to perform this action
    */
   const handleDoubbleClick = (e, movedBlock, draggable, index) => {
+    setSelectedBlock(movedBlock);
 
     if(movedBlock != null && draggable){
     
-    // the user selected this codeblock
-    movedBlock.index = index;
-    setSelectedBlock(movedBlock);
+      // the user selected this codeblock
+      movedBlock.index = index;
 
-    // (e.detauil > 1) if clicked more than once
-    if(e.detail > 1){
-      movedBlock.indent = 0;
-      dispatch(removeBlockFromField(movedBlock.id));
-      dispatch(addBlockToList(movedBlock));
-      fieldEventPromise().then(() => dispatch(listEvent()));
-      e.detail = 0; // resets detail so that other codeblocks can be clicked
-      };
-    }
+      // (e.detauil > 1) if clicked more than once
+      if(e.detail > 1){
+        movedBlock.indent = 0;
+        dispatch(removeBlockFromField(movedBlock.id));
+        dispatch(addBlockToList(movedBlock));
+        fieldEventPromise().then(() => dispatch(listEvent()));
+        e.detail = 0; // resets detail so that other codeblocks can be clicked
+        };
+      }
   };
 
   return (
@@ -200,6 +203,7 @@ function SolutionField({}) {
               draggable={true}
               key={`line-${index}`}
               handleDoubbleClick = {handleDoubbleClick}
+              isSelected = {selectedBlock}
             />
           );
         })}


### PR DESCRIPTION
## Hva er nytt?
- Border på selected codelines
- I moveblock fjernes selected codelines om det skjer ved DnD eller dobbeltklikk
- Fikset bug der tab og backspace endret på adressefelt
- Shift tab gjør nå det samme som backspace