### PR TITLE
select bugs

### DIFF
--- a/app/src/components/game/Sidebar/Sidebar.js
+++ b/app/src/components/game/Sidebar/Sidebar.js
@@ -46,8 +46,18 @@ export default function Sidebar() {
    * Reset current hint when a new task is started.
    */
   useEffect(() => {
+    setModalIsOpen(false);
     setCurrentHintNo(0);
   }, [currentTask]);
+
+  /**
+   * Update the hint modal when changing current hint number
+   */
+  useEffect(() => {
+    if (modalIsOpen) {
+      handleHint();
+    }
+  }, [currentHintNo]);
 
   /* Close the modal. Callback from SideBarModal*/
   const closeModal = () => {
@@ -152,9 +162,7 @@ export default function Sidebar() {
    */
   const handleSubmit = () => {
     closeModal();
-
     setCurrentFieldBlocks(fieldBlocks);
-
     let correctSolution = arrayIsEqual(
       fieldBlocks,
       currentTaskObject.codeBlocks
@@ -247,7 +255,6 @@ export default function Sidebar() {
     }
 
     setCurrentHintNo(updatedCurrentHintNo);
-    handleHint();
   };
 
   return (
@@ -279,7 +286,6 @@ export default function Sidebar() {
           icon={HintIcon}
           color={COLORS.lightyellow}
           handleClick={() => {
-            changeHint('+');
             handleHint();
           }}
         />

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -25,6 +25,7 @@ import { COLORS, MAX_INDENT, KEYBOARD_EVENT } from '../../../utils/constants';
  * @returns a div containing the blocks players has moved blocks into
  */
 function SolutionField({}) {
+  const currentTaskNumber = useSelector((state) => state.currentTask.currentTaskNumber);
   const blocks = useSelector((state) => state.solutionField);
   const players = useSelector((state) => state.players);
   const dispatch = useDispatch();
@@ -71,19 +72,24 @@ function SolutionField({}) {
    */
   const handleKeyDown = useCallback(e=> {
     e.preventDefault();     // do not target adress bar
-      if(selectedCodeline != null && findBlock(selectedCodeline.id) !== undefined && e.keyCode != null){               
-        if((e.shiftKey && e.keyCode == KEYBOARD_EVENT.TAB  && selectedCodeline.indent > 0) || (e.keyCode === KEYBOARD_EVENT.BACKSPACE  && selectedCodeline.indent > 0)) { 
-          // SHIFT TAB OR BACKSPACE
-          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent-1}))
-          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent -1, false);
-        }
-        else if (!e.shiftKey && e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {
-          // TAB      
-          setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
-          moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
-        }
+    if(selectedCodeline != null && findBlock(selectedCodeline.id) !== undefined && e.keyCode != null){               
+      if((e.shiftKey && e.keyCode == KEYBOARD_EVENT.TAB  && selectedCodeline.indent > 0) || (e.keyCode === KEYBOARD_EVENT.BACKSPACE  && selectedCodeline.indent > 0)) { 
+        // SHIFT TAB OR BACKSPACE
+        setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent-1}))
+        moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent -1, false);
+      }
+      else if (!e.shiftKey && e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {
+        // TAB      
+        setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
+        moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
+      }
     } 
   },);
+
+  /* Reset selected block when a new task starts*/
+  useEffect(() => {
+    setSelectedCodeline(null)
+  }, [currentTaskNumber]);
 
   /**
    * Creates an key event listener based on the selected codeblock

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -71,12 +71,14 @@ function SolutionField({}) {
    */
   const handleKeyDown = useCallback(e=> {
     e.preventDefault();     // do not target adress bar
-      if(selectedCodeline != null && e.keyCode != null){               // SHIFT TAB OR BACKSPACE
+      if(selectedCodeline != null && findBlock(selectedCodeline.id) !== undefined && e.keyCode != null){               
         if((e.shiftKey && e.keyCode == KEYBOARD_EVENT.TAB  && selectedCodeline.indent > 0) || (e.keyCode === KEYBOARD_EVENT.BACKSPACE  && selectedCodeline.indent > 0)) { 
+          // SHIFT TAB OR BACKSPACE
           setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent-1}))
           moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent -1, false);
         }
-        else if (!e.shiftKey && e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {      // TAB
+        else if (!e.shiftKey && e.keyCode === KEYBOARD_EVENT.TAB && selectedCodeline.indent < MAX_INDENT) {
+          // TAB      
           setSelectedCodeline((selectedCodeline) => ({...selectedCodeline, indent: selectedCodeline.indent+1}))
           moveBlock(selectedCodeline.id, selectedCodeline.index, selectedCodeline.indent +1, false);
         }


### PR DESCRIPTION
- Fikset bug der en spiller kunne tabbe selv om brikken var flyttet til hånden. Nå sjekker den at brikken er i solutionfield før tabbing (findblock).
- Fikset bug der id til en codeblock forble selected når du går til neste task. Solutionfield bruker nå useEffect på currentTaskNumber for å nullstille selectedblock