### PR TITLE
Move locally

### DIFF
--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -274,20 +274,20 @@ class CommunicationHandler extends Component {
 
     let timePast = lastMoveHost - lastMoveMe;
 
-    /*     console.log(timePast);
+    //console.log(timePast);
 
-    console.log(
+    /*console.log(
       store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
     ); */
 
     // As long as this is after my last move
-    //if (timePast > this.EVENT_DELAY) {
-    if (
-      !twoDimensionalArrayIsEqual(prevState.handList, payloadState.handList)
-    ) {
-      dispatch_setListState(payloadState.handList);
+    if (timePast > this.EVENT_DELAY) {
+      if (
+        !twoDimensionalArrayIsEqual(prevState.handList, payloadState.handList)
+      ) {
+        dispatch_setListState(payloadState.handList);
+      }
     }
-    //}
   }
 
   /**
@@ -312,11 +312,11 @@ class CommunicationHandler extends Component {
     ); */
 
     // As long as this is after my last move
-    //if (timePast > this.EVENT_DELAY) {
-    if (!arrayIsEqual(prevSolution, solutionField)) {
-      dispatch_setFieldState(solutionField);
+    if (timePast > this.EVENT_DELAY) {
+      if (!arrayIsEqual(prevSolution, solutionField)) {
+        dispatch_setFieldState(solutionField);
+      }
     }
-    //}
   }
 
   /**

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -283,9 +283,17 @@ class CommunicationHandler extends Component {
     const { dispatch_setFieldState } = this.props;
     const prevState = store.getState().solutionField;
     const payloadState = JSON.parse(payload);
+    const solutionField = payloadState.solutionField;
 
-    if (!arrayIsEqual(prevState, payloadState)) {
-      dispatch_setFieldState(payloadState);
+    console.log(
+      store.getState().moveRequest.timestamp > payloadState.timestamp
+    );
+
+    // As long as this is after my last move
+    if (store.getState().moveRequest.timestamp < payloadState.timestamp) {
+      if (!arrayIsEqual(prevState, solutionField)) {
+        dispatch_setFieldState(solutionField);
+      }
     }
   }
 

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -37,6 +37,7 @@ import {
   SELECT_REQUEST,
   SELECT_EVENT,
   SET_TASKSET,
+  SET_LISTS_AND_FIELD,
 } from './messages';
 import {
   twoDimensionalArrayIsEqual,
@@ -220,6 +221,9 @@ class CommunicationHandler extends Component {
    */
   handlePeerData = (webrtc, type, payload, peer) => {
     switch (type) {
+      case SET_LISTS_AND_FIELD:
+        this.setField(payload);
+        this.setList(payload);
       case SET_FIELD:
         this.setField(payload);
         break;
@@ -274,7 +278,7 @@ class CommunicationHandler extends Component {
 
     let timePast = lastMoveHost - lastMoveMe;
 
-    //console.log(timePast);
+    console.log(timePast);
 
     /*console.log(
       store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
@@ -282,11 +286,7 @@ class CommunicationHandler extends Component {
 
     // As long as this is after my last move
     if (timePast > this.EVENT_DELAY) {
-      if (
-        !twoDimensionalArrayIsEqual(prevState.handList, payloadState.handList)
-      ) {
-        dispatch_setListState(payloadState.handList);
-      }
+      dispatch_setListState(payloadState.handList);
     }
   }
 
@@ -298,7 +298,7 @@ class CommunicationHandler extends Component {
   setField(payload) {
     const { dispatch_setFieldState } = this.props;
     const prevState = store.getState();
-    const prevSolution = prevState.solutionField;
+
     const payloadState = JSON.parse(payload);
     const solutionField = payloadState.solutionField;
     const lastMoveMe = prevState.moveRequest.timestamp;
@@ -313,9 +313,7 @@ class CommunicationHandler extends Component {
 
     // As long as this is after my last move
     if (timePast > this.EVENT_DELAY) {
-      if (!arrayIsEqual(prevSolution, solutionField)) {
-        dispatch_setFieldState(solutionField);
-      }
+      dispatch_setFieldState(solutionField);
     }
   }
 

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -274,18 +274,11 @@ class CommunicationHandler extends Component {
     const prevState = store.getState();
     const payloadState = JSON.parse(payload);
     const lastMoveMe = prevState.moveRequest.timestamp;
-    //const lastMoveHost = payloadState.timestamp;
 
     let now = new Date().getTime();
     let timePast = now - lastMoveMe;
 
-    console.log(timePast);
-
-    /*console.log(
-      store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
-    ); */
-
-    // As long as this is after my last move
+    // If I have not moved a block the last second
     if (timePast > this.EVENT_DELAY) {
       dispatch_setListState(payloadState.handList);
     }
@@ -303,17 +296,10 @@ class CommunicationHandler extends Component {
     const payloadState = JSON.parse(payload);
     const solutionField = payloadState.solutionField;
     const lastMoveMe = prevState.moveRequest.timestamp;
-    //const lastMoveHost = payloadState.timestamp;
-
     let now = new Date().getTime();
     let timePast = now - lastMoveMe;
 
-    /*  console.log(timePast);
-    console.log(
-      store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
-    ); */
-
-    // As long as this is after my last move
+    // If I have not moved a block the last second
     if (timePast > this.EVENT_DELAY) {
       dispatch_setFieldState(solutionField);
     }

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -114,7 +114,7 @@ class CommunicationHandler extends Component {
   }
 
   isProduction = JSON.parse(configData.PRODUCTION);
-  EVENT_DELAY = 500;
+  EVENT_DELAY = 1000;
 
   /* Close the modal. Callback from SideBarModal*/
   closeModal() {
@@ -274,9 +274,10 @@ class CommunicationHandler extends Component {
     const prevState = store.getState();
     const payloadState = JSON.parse(payload);
     const lastMoveMe = prevState.moveRequest.timestamp;
-    const lastMoveHost = payloadState.timestamp;
+    //const lastMoveHost = payloadState.timestamp;
 
-    let timePast = lastMoveHost - lastMoveMe;
+    let now = new Date().getTime();
+    let timePast = now - lastMoveMe;
 
     console.log(timePast);
 
@@ -302,9 +303,10 @@ class CommunicationHandler extends Component {
     const payloadState = JSON.parse(payload);
     const solutionField = payloadState.solutionField;
     const lastMoveMe = prevState.moveRequest.timestamp;
-    const lastMoveHost = payloadState.timestamp;
+    //const lastMoveHost = payloadState.timestamp;
 
-    let timePast = lastMoveHost - lastMoveMe;
+    let now = new Date().getTime();
+    let timePast = now - lastMoveMe;
 
     /*  console.log(timePast);
     console.log(

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -284,13 +284,18 @@ class CommunicationHandler extends Component {
     const prevState = store.getState().solutionField;
     const payloadState = JSON.parse(payload);
     const solutionField = payloadState.solutionField;
+    const lastMoveMe = store.getState().moveRequest.timestamp;
+    const lastMoveHost = payloadState.timestamp;
 
+    let timePast = lastMoveHost - lastMoveMe;
+
+    console.log(timePast);
     console.log(
-      store.getState().moveRequest.timestamp > payloadState.timestamp
+      store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
     );
 
     // As long as this is after my last move
-    if (store.getState().moveRequest.timestamp < payloadState.timestamp) {
+    if (timePast > 500) {
       if (!arrayIsEqual(prevState, solutionField)) {
         dispatch_setFieldState(solutionField);
       }

--- a/app/src/components/communication/webrtc/CommunicationHandler.js
+++ b/app/src/components/communication/webrtc/CommunicationHandler.js
@@ -113,6 +113,7 @@ class CommunicationHandler extends Component {
   }
 
   isProduction = JSON.parse(configData.PRODUCTION);
+  EVENT_DELAY = 500;
 
   /* Close the modal. Callback from SideBarModal*/
   closeModal() {
@@ -266,12 +267,27 @@ class CommunicationHandler extends Component {
    */
   setList(payload) {
     const { dispatch_setListState } = this.props;
-    const prevState = store.getState().handList;
+    const prevState = store.getState();
     const payloadState = JSON.parse(payload);
+    const lastMoveMe = prevState.moveRequest.timestamp;
+    const lastMoveHost = payloadState.timestamp;
 
-    if (!twoDimensionalArrayIsEqual(prevState, payloadState)) {
+    let timePast = lastMoveHost - lastMoveMe;
+
+    /*     console.log(timePast);
+
+    console.log(
+      store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
+    ); */
+
+    // As long as this is after my last move
+    //if (timePast > this.EVENT_DELAY) {
+    if (
+      !twoDimensionalArrayIsEqual(prevState.handList, payloadState.handList)
+    ) {
       dispatch_setListState(payloadState.handList);
     }
+    //}
   }
 
   /**
@@ -281,25 +297,26 @@ class CommunicationHandler extends Component {
    */
   setField(payload) {
     const { dispatch_setFieldState } = this.props;
-    const prevState = store.getState().solutionField;
+    const prevState = store.getState();
+    const prevSolution = prevState.solutionField;
     const payloadState = JSON.parse(payload);
     const solutionField = payloadState.solutionField;
-    const lastMoveMe = store.getState().moveRequest.timestamp;
+    const lastMoveMe = prevState.moveRequest.timestamp;
     const lastMoveHost = payloadState.timestamp;
 
     let timePast = lastMoveHost - lastMoveMe;
 
-    console.log(timePast);
+    /*  console.log(timePast);
     console.log(
       store.getState().moveRequest.timestamp + ' --- ' + payloadState.timestamp
-    );
+    ); */
 
     // As long as this is after my last move
-    if (timePast > 500) {
-      if (!arrayIsEqual(prevState, solutionField)) {
-        dispatch_setFieldState(solutionField);
-      }
+    //if (timePast > this.EVENT_DELAY) {
+    if (!arrayIsEqual(prevSolution, solutionField)) {
+      dispatch_setFieldState(solutionField);
     }
+    //}
   }
 
   /**

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -92,11 +92,50 @@ class CommunicationListener extends Component {
   EVENT_DELAY = 2000;
   timer = null;
 
+  /**
+   * Checks that a block with a given id only is present once in the lists
+   *
+   * @param {*} state
+   */
+  removeDuplicates(state) {
+    let blockIds = [];
+    let newField = [];
+    let newList = [];
+
+    for (let block of state.solutionField) {
+      if (!blockIds.includes(block.id)) {
+        blockIds.push(block.id);
+        newField.push(block);
+      }
+    }
+
+    for (let playerList of state.handList) {
+      let newPlayerList = [];
+      for (let block of playerList) {
+        if (!blockIds.includes(block.id)) {
+          blockIds.push(block.id);
+          newPlayerList.push(block);
+        }
+      }
+      newList.push(newPlayerList);
+    }
+
+    const { dispatch_setFieldState, dispatch_setListState } = this.props;
+    dispatch_setFieldState(newField);
+    dispatch_setListState(newList);
+  }
+
+  /**
+   * The HOST holds the correct state and synchronizes all players on a given interval
+   */
   hearthbeat() {
     this.timer = setInterval(() => {
       let state = store.getState();
       if (this.iAmHost(state.host)) {
         let now = new Date().getTime();
+
+        // Checks that a block with a given id only is present once in the lists
+        this.removeDuplicates(state);
 
         // If there has not been a FIELD update since last hearthbeat
         if (now - state.fieldEvent > this.EVENT_DELAY) {

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -263,7 +263,10 @@ class CommunicationListener extends Component {
         this.whisper(state.host, MOVE_REQUEST, state.moveRequest);
         break;
       case prevProps.fieldEvent !== this.props.fieldEvent: // Block moved in field
-        this.shout(SET_FIELD, state.solutionField);
+        this.shout(SET_FIELD, {
+          solutionField: state.solutionField,
+          timestamp: this.props.fieldEvent.getTime(),
+        });
         break;
       case prevProps.listEvent !== this.props.listEvent: // Block moved in list
         this.shout(SET_LIST, {

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -98,12 +98,8 @@ class CommunicationListener extends Component {
       if (this.iAmHost(state.host)) {
         let now = new Date().getTime();
 
-        // If there has not been a FIELD update since last hearbeat
+        // If there has not been a FIELD update since last hearthbeat
         if (now - state.fieldEvent > this.EVENT_DELAY) {
-          console.log(
-            'more than ' + this.EVENT_DELAY + ' milliseconds since last move'
-          );
-
           const { dispatch_fieldEvent } = this.props;
           dispatch_fieldEvent();
         }
@@ -222,7 +218,6 @@ class CommunicationListener extends Component {
       this.shout(SET_LISTS_AND_FIELD, {
         solutionField: state.solutionField,
         handList: state.handList,
-        timestamp: state.fieldEvent.getTime(),
       });
     } else this.whisper(state.host, CLEAR_TASK, '');
   }
@@ -294,7 +289,6 @@ class CommunicationListener extends Component {
         this.shout(SET_LISTS_AND_FIELD, {
           solutionField: state.solutionField,
           handList: state.handList,
-          timestamp: this.props.fieldEvent.getTime(),
         });
         break;
       case prevProps.clearEvent.getTime() < this.props.clearEvent.getTime(): // I cleared the board

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -89,11 +89,11 @@ class CommunicationListener extends Component {
 
   isProduction = JSON.parse(configData.PRODUCTION);
   HEARTHBEAT_INTERVAL = 100;
-  EVENT_DELAY = 2000;
+  EVENT_DELAY = 1000;
   timer = null;
 
   hearthbeat() {
-    /* this.timer = setInterval(() => {
+    this.timer = setInterval(() => {
       //console.log('this will run every ' + this.EVENT_DELAY + ' milliseconds');
       let state = store.getState();
       let now = new Date().getTime();
@@ -111,7 +111,7 @@ class CommunicationListener extends Component {
         dispatch_fieldEvent();
         dispatch_listEvent();
       }
-    }, this.HEARTHBEAT_INTERVAL); */
+    }, this.HEARTHBEAT_INTERVAL);
   }
 
   /**

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -88,7 +88,31 @@ class CommunicationListener extends Component {
   }
 
   isProduction = JSON.parse(configData.PRODUCTION);
-  EVENT_DELAY = 0;
+  HEARTHBEAT_INTERVAL = 100;
+  EVENT_DELAY = 2000;
+  timer = null;
+
+  hearthbeat() {
+    /* this.timer = setInterval(() => {
+      //console.log('this will run every ' + this.EVENT_DELAY + ' milliseconds');
+      let state = store.getState();
+      let now = new Date().getTime();
+
+      // If there has not been a FIELD or LIST update since last hearbeat
+      if (
+        now - state.fieldEvent > this.EVENT_DELAY ||
+        now - state.listEvent > this.EVENT_DELAY
+      ) {
+        console.log(
+          'more than ' + this.EVENT_DELAY + ' milliseconds since last move'
+        );
+
+        const { dispatch_fieldEvent, dispatch_listEvent } = this.props;
+        dispatch_fieldEvent();
+        dispatch_listEvent();
+      }
+    }, this.HEARTHBEAT_INTERVAL); */
+  }
 
   /**
    * Distribute cards to all players, including yourself
@@ -136,6 +160,8 @@ class CommunicationListener extends Component {
     this.initialize_board();
     const { dispatch_startGame } = this.props;
     dispatch_startGame();
+
+    this.hearthbeat();
   }
 
   /**
@@ -200,6 +226,7 @@ class CommunicationListener extends Component {
       dispatch_lockEvent({ pid: 'ALL_PLAYERS', lock: false });
       let payload = {
         handList: state.handList,
+        timestamp: this.props.listEvent.getTime(),
       };
       this.shout(SET_LIST, payload);
       this.shout(SET_FIELD, {
@@ -273,6 +300,7 @@ class CommunicationListener extends Component {
       case prevProps.listEvent !== this.props.listEvent: // Block moved in list
         this.shout(SET_LIST, {
           handList: state.handList,
+          timestamp: state.listEvent.getTime(),
         });
         break;
       case prevProps.clearEvent.getTime() < this.props.clearEvent.getTime(): // I cleared the board

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -89,24 +89,24 @@ class CommunicationListener extends Component {
   }
 
   isProduction = JSON.parse(configData.PRODUCTION);
-  HEARTHBEAT_INTERVAL = 100;
-  EVENT_DELAY = 1000;
+  EVENT_DELAY = 2000;
   timer = null;
 
   hearthbeat() {
     this.timer = setInterval(() => {
-      //console.log('this will run every ' + this.EVENT_DELAY + ' milliseconds');
       let state = store.getState();
-      let now = new Date().getTime();
+      if (this.iAmHost(state.host)) {
+        let now = new Date().getTime();
 
-      // If there has not been a FIELD update since last hearbeat
-      if (now - state.fieldEvent > this.EVENT_DELAY) {
-        console.log(
-          'more than ' + this.EVENT_DELAY + ' milliseconds since last move'
-        );
+        // If there has not been a FIELD update since last hearbeat
+        if (now - state.fieldEvent > this.EVENT_DELAY) {
+          console.log(
+            'more than ' + this.EVENT_DELAY + ' milliseconds since last move'
+          );
 
-        const { dispatch_fieldEvent } = this.props;
-        dispatch_fieldEvent();
+          const { dispatch_fieldEvent } = this.props;
+          dispatch_fieldEvent();
+        }
       }
     }, this.EVENT_DELAY);
   }
@@ -157,8 +157,6 @@ class CommunicationListener extends Component {
     this.initialize_board();
     const { dispatch_startGame } = this.props;
     dispatch_startGame();
-
-    this.hearthbeat();
   }
 
   /**
@@ -264,6 +262,13 @@ class CommunicationListener extends Component {
     if (state.status === STATUS.GAME) {
       this.shout(START_GAME, payload);
     }
+  }
+  componentDidMount() {
+    this.hearthbeat();
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timer);
   }
 
   /**

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -202,8 +202,10 @@ class CommunicationListener extends Component {
         handList: state.handList,
       };
       this.shout(SET_LIST, payload);
-      payload = state.solutionField;
-      this.shout(SET_FIELD, payload);
+      this.shout(SET_FIELD, {
+        solutionField: state.solutionField,
+        timestamp: this.props.fieldEvent.getTime(),
+      });
     } else this.whisper(state.host, CLEAR_TASK, '');
   }
 

--- a/app/src/components/communication/webrtc/CommunicationListener.js
+++ b/app/src/components/communication/webrtc/CommunicationListener.js
@@ -297,10 +297,19 @@ class CommunicationListener extends Component {
       this.shout(START_GAME, payload);
     }
   }
+
+  /**
+   * Start hearthbeat on mount
+   */
   componentDidMount() {
-    this.hearthbeat();
+    setTimeout(() => {
+      this.hearthbeat();
+    }, this.EVENT_DELAY);
   }
 
+  /**
+   * End hearthbeat on unmount
+   */
   componentWillUnmount() {
     clearInterval(this.timer);
   }

--- a/app/src/components/communication/webrtc/messages.js
+++ b/app/src/components/communication/webrtc/messages.js
@@ -10,3 +10,4 @@ export const LOCK_EVENT = 'LOCK_EVENT';
 export const SELECT_REQUEST = 'SELECT_REQUEST';
 export const SELECT_EVENT = 'SELECT_EVENT';
 export const SET_TASKSET = 'SET_TASKSET';
+export const SET_LISTS_AND_FIELD = 'SET_LISTS_AND_FIELD';

--- a/app/src/components/game/HandList/HandList.jsx
+++ b/app/src/components/game/HandList/HandList.jsx
@@ -150,16 +150,16 @@ function HandList({ player, draggable }) {
     if (!locked && e.detail > 1 && draggable && movedBlock != null) {
       let index = store.getState().solutionField.length + 1;
       // (e.detauil > 1) if clicked more than once
-      if (iAmHost()) {
-        dispatch(removeBlockFromList(movedBlock.id, movedBlock.player - 1));
-        dispatch(addBlockToField(movedBlock));
-        fieldEventPromise().then(() => dispatch(listEvent()));
-      } else {
+      dispatch(removeBlockFromList(movedBlock.id, movedBlock.player - 1));
+      dispatch(addBlockToField(movedBlock));
+      fieldEventPromise().then(() => dispatch(listEvent()));
+      if (!iAmHost()) {
         const move = {
           id: movedBlock.id,
           index: index,
           indent: 0,
           field: 'SF',
+          timestamp: new Date().getTime()
         };
         requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
       }

--- a/app/src/components/game/HandList/HandList.jsx
+++ b/app/src/components/game/HandList/HandList.jsx
@@ -82,7 +82,6 @@ function HandList({ player, draggable }) {
   // update the position of the block when moved inside a list
   const moveBlock = useCallback(
     (id, atIndex, atIndent = 0) => {
-      if (iAmHost()) {
         // do move locally
         moveBlockInHandList(
           id,
@@ -92,13 +91,14 @@ function HandList({ player, draggable }) {
           handListIndex,
           dispatches
         );
-      } else {
+      if (!iAmHost()) {
         // request move to host
         const move = {
           id,
           index: atIndex,
           indent: atIndent,
           field: player.toString(),
+          timestamp: new Date().getTime()
         };
         requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
       }

--- a/app/src/components/game/Sidebar/Sidebar.js
+++ b/app/src/components/game/Sidebar/Sidebar.js
@@ -178,22 +178,20 @@ function Sidebar() {
    * Clear the board. If host: perform locally before dispatching field and list event. If not: request to host.
    */
   const clearBoard = () => {
-    if (iAmHost()) {
-      // Clear locally then update all players
-      let initalfield = currentTaskObject.field;
-      let state = store.getState();
-      let field = state.solutionField;
-      let handList = state.handList;
-      handList = clearBoardHelper(field, handList);
-      let players = state.players;
-      dispatch(setPlayers(setAllLocks(players, false)));
-      dispatch(lockEvent({ pid: LOCKTYPES.ALL_PLAYERS, lock: false }));
-      dispatch(setFieldState(initalfield));
-      dispatch(setListState(handList));
-      dispatch(clearEvent()); // Request clear to host
-    } else {
+    // Clear locally then update all players
+    let initalfield = currentTaskObject.field;
+    let state = store.getState();
+    let field = state.solutionField;
+    let handList = state.handList;
+    handList = clearBoardHelper(field, handList);
+    let players = state.players;
+    dispatch(setPlayers(setAllLocks(players, false)));
+    dispatch(lockEvent({ pid: LOCKTYPES.ALL_PLAYERS, lock: false }));
+    dispatch(setFieldState(initalfield));
+    dispatch(setListState(handList));
+    dispatch(clearEvent()); // Request clear to host
+    if (!iAmHost()) {
       dispatch(lockRequest({ forWho: LOCKTYPES.ALL_PLAYERS }));
-      dispatch(clearEvent()); // Request clear to host
     }
     closeModal();
   };

--- a/app/src/components/game/Sidebar/Sidebar.js
+++ b/app/src/components/game/Sidebar/Sidebar.js
@@ -207,21 +207,19 @@ function Sidebar() {
    * Handle a click on the lock button.
    */
   const handleLock = () => {
-    // If I am the HOST I update for myself and the other players
-    if (iAmHost()) {
-      let players = store.getState().players;
+    let players = store.getState().players;
 
-      dispatch(
-        lockEvent({
-          pid: 'HOST',
-          lock: !locked,
-        })
-      );
-      dispatch(setPlayers(setLock(players, 'YOU', !locked)));
-      setNumberOfLockedInPlayers(
-        getAllLocks(players).filter((lock) => lock === true).length
-      );
-    } else {
+    dispatch(
+      lockEvent({
+        pid: 'HOST',
+        lock: !locked,
+      })
+    );
+    dispatch(setPlayers(setLock(players, 'YOU', !locked)));
+    setNumberOfLockedInPlayers(
+      getAllLocks(players).filter((lock) => lock === true).length
+    );
+    if (!iAmHost()) {
       // If I am not he HOST I need to ask for permission
       dispatch(lockRequest({ forWho: LOCKTYPES.FOR_MYSELF }));
     }

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -316,8 +316,16 @@ function SolutionField({ minwidth }) {
     if (!locked && movedBlock != null && draggable) {
         // the user selected this codeblock
         setSelectedCodeline(movedBlock);
-        movedBlock.index = index;
-        select(index, 'ME')
+        if(movedBlock !== null){
+          movedBlock.index = index;
+          select(index, 'ME')
+
+        }
+        else{
+          select(null, 'ME')
+        }
+        
+        
         
         // (e.detauil > 1) if clicked more than once
         if (e.detail > 1) {
@@ -337,14 +345,12 @@ function SolutionField({ minwidth }) {
               timestamp: new Date().getTime()
             };
             requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
+           
           }
         }
       }
 
-      if(movedBlock === selectedCodeline ){
-        select(null, 'ME')
-        setSelectedCodeline(null);
-      }
+     
 
     e.detail = 0; // resets detail so that other codeblocks can be clicked
   };

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -318,14 +318,11 @@ function SolutionField({ minwidth }) {
         setSelectedCodeline(movedBlock);
         if(movedBlock !== null){
           movedBlock.index = index;
-          select(index, 'ME')
-
+          select(index, 'ME');
         }
         else{
-          select(null, 'ME')
+          select(null, 'ME');
         }
-        
-        
         
         // (e.detauil > 1) if clicked more than once
         if (e.detail > 1) {

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -250,7 +250,11 @@ function SolutionField({ minwidth }) {
       let players = store.getState().players;
       let newSelectedBlocks = getSelectedBlocks(players);
       if(newSelectedBlocks != null && newSelectedBlocks != allSelectedLines){
-        // Update indicators if they are different
+        // Update indicators if they are different, 
+        const myIndex = players.findIndex(object => {
+          return object.id === 'YOU';
+        });
+        newSelectedBlocks[myIndex] = null   // Do not keep track of my own index
         setAllSelectedLines(newSelectedBlocks);
         let mySelectedBlock = getSelectedBy(players, 'YOU');
         if(selectedCodeline != null && mySelectedBlock !== selectedCodeline.index){

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -250,12 +250,6 @@ function SolutionField({ minwidth }) {
       let players = store.getState().players;
       let newSelectedBlocks = getSelectedBlocks(players);
       if(newSelectedBlocks != null && newSelectedBlocks != allSelectedLines){
-        // Update indicators if they are different, 
-        const myIndex = players.findIndex(object => {
-          return object.id === 'YOU';
-        });
-        newSelectedBlocks[myIndex] = null   // Do not keep track of my own index
-        setAllSelectedLines(newSelectedBlocks);
         let mySelectedBlock = getSelectedBy(players, 'YOU');
         if(selectedCodeline != null && mySelectedBlock !== selectedCodeline.index){
           // Update my selected codeline if they are different
@@ -263,6 +257,12 @@ function SolutionField({ minwidth }) {
           if(selected != null) selected.index = mySelectedBlock;
           setSelectedCodeline(selected);
         }
+        // Update indicators if they are different, 
+        const myIndex = players.findIndex(object => {
+          return object.id === 'YOU';
+        });
+        newSelectedBlocks[myIndex] = null   // Do not keep track of my own index
+        setAllSelectedLines(newSelectedBlocks);
       }
     }, [newSelectEvent]);
 

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -98,8 +98,7 @@ function SolutionField({ minwidth }) {
   const moveBlock = useCallback(
     (id, atIndex, atIndent = 0) => {
       // get block if it exists in solutionfield
-      if (iAmHost()) {
-          moveBlockInSolutionField(
+        moveBlockInSolutionField(
           id,
           atIndex,
           atIndent,
@@ -107,8 +106,8 @@ function SolutionField({ minwidth }) {
           store.getState().handList,
           dispatches
         );
-      } else {
-        const move = { id, index: atIndex, indent: atIndent, field: 'SF' };
+      if (!iAmHost()) {
+        const move = { id, index: atIndex, indent: atIndent, field: 'SF' , timestamp: new Date().getTime()};
         requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
       }
     },

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -321,12 +321,11 @@ function SolutionField({ minwidth }) {
         
         // (e.detauil > 1) if clicked more than once
         if (e.detail > 1) {
-          if (iAmHost()) {
-            movedBlock.indent = 0;
-            dispatch(removeBlockFromField(movedBlock.id));
-            dispatch(addBlockToList(movedBlock));
-            fieldEventPromise().then(() => dispatch(listEvent()));
-          } else {
+          movedBlock.indent = 0;
+          dispatch(removeBlockFromField(movedBlock.id));
+          dispatch(addBlockToList(movedBlock));
+          fieldEventPromise().then(() => dispatch(listEvent()));
+          if (!iAmHost()) {
             const playerField = movedBlock.player.toString();
             const listIndex = movedBlock.player - 1;
             const atIndex = store.getState().handList[listIndex].length;
@@ -335,6 +334,7 @@ function SolutionField({ minwidth }) {
               index: atIndex,
               indent: 0,
               field: playerField,
+              timestamp: new Date().getTime()
             };
             requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
           }

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -342,12 +342,9 @@ function SolutionField({ minwidth }) {
               timestamp: new Date().getTime()
             };
             requestMove(move, store.getState().moveRequest, dispatch_moveRequest);
-           
           }
         }
       }
-
-     
 
     e.detail = 0; // resets detail so that other codeblocks can be clicked
   };

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -317,13 +317,22 @@ function SolutionField({ minwidth }) {
    * @param {*} draggable : wheter or not the player has permission to perform this action
    */
   const handleDoubbleClick = (e, movedBlock, draggable, index) => {
+
+
     if (!locked && movedBlock != null && draggable) {
+        
         // the user selected this codeblock
         setSelectedCodeline(movedBlock);
         if(movedBlock !== null){
-          movedBlock.index = index;
-          select(index, 'ME');
+          if(selectedCodeline !=null && selectedCodeline.index === movedBlock.index){
+            setSelectedCodeline(null);
+            select(null, 'ME')
+          }else {
+            movedBlock.index = index;
+            select(index, 'ME');
+          }
         }
+
         
         // (e.detauil > 1) if clicked more than once
         if (e.detail > 1) {
@@ -347,8 +356,9 @@ function SolutionField({ minwidth }) {
           }
         }
       }
-
+ 
     e.detail = 0; // resets detail so that other codeblocks can be clicked
+
   };
 
   /**

--- a/app/src/components/game/SolutionField/SolutionField.jsx
+++ b/app/src/components/game/SolutionField/SolutionField.jsx
@@ -320,12 +320,10 @@ function SolutionField({ minwidth }) {
           movedBlock.index = index;
           select(index, 'ME');
         }
-        else{
-          select(null, 'ME');
-        }
         
         // (e.detauil > 1) if clicked more than once
         if (e.detail > 1) {
+          handleDroppedLine(index);
           movedBlock.indent = 0;
           dispatch(removeBlockFromField(movedBlock.id));
           dispatch(addBlockToList(movedBlock));

--- a/app/src/config.json
+++ b/app/src/config.json
@@ -1,4 +1,4 @@
 {
-  "SERVER_URL": "http://16.171.11.232:8888/",
+  "SERVER_URL": "http://13.53.200.7:8888/",
   "PRODUCTION": "true"
 }

--- a/app/src/redux/reducers/gameLogic/moveRequest.js
+++ b/app/src/redux/reducers/gameLogic/moveRequest.js
@@ -5,6 +5,7 @@ const initialState = {
   index: undefined,
   indent: undefined,
   field: undefined,
+  timestamp: new Date().getTime(),
 };
 
 /**  Reducer for storing the last move request a player has done.

--- a/app/src/utils/moveBlock/moveBlock.js
+++ b/app/src/utils/moveBlock/moveBlock.js
@@ -191,8 +191,8 @@ const moveBlockFromField = (
       ...handList.slice(index),
     ];
 
-    dispatch_setList(updatedBlocks, handListIndex);
     dispatch_removeBlockFromField(id);
+    dispatch_setList(updatedBlocks, handListIndex);
     if (iAmHost()) dispatch_fieldEvent();
   }
 };

--- a/app/src/utils/moveBlock/moveBlock.js
+++ b/app/src/utils/moveBlock/moveBlock.js
@@ -1,4 +1,12 @@
 import update from 'immutability-helper';
+import store from '../../redux/store/store';
+
+/**
+ * @returns true if this player is the host.
+ */
+const iAmHost = () => {
+  return store.getState().host === '';
+};
 
 /**
  * Move a code block in a hand list. Either swap position or move block from solution field.
@@ -41,7 +49,7 @@ export const moveBlockInHandList = (
       handListIndex,
       dispatches
     );
-  dispatch_listEvent(); // Move the block for the other players
+  if (iAmHost()) dispatch_listEvent(); // Move the block for the other players
 };
 
 /**
@@ -77,7 +85,7 @@ export const moveBlockInSolutionField = (
       dispatches
     );
   }
-  dispatch_fieldEvent(); // Move the block for the other players
+  if (iAmHost()) dispatch_fieldEvent(); // Move the block for the other players
 };
 
 /**
@@ -135,7 +143,7 @@ const moveBlockFromList = (id, index, solutionField, handLists, dispatches) => {
         blockIsNotFound = false;
         movedBlock = handLists[handListIndex][block];
         dispatch_removeBlockFromList(id, handListIndex);
-        dispatch_listEvent();
+        if (iAmHost()) dispatch_listEvent();
         const updatedBlocks = [
           ...solutionField.slice(0, index),
           movedBlock,
@@ -185,7 +193,7 @@ const moveBlockFromField = (
 
     dispatch_setList(updatedBlocks, handListIndex);
     dispatch_removeBlockFromField(id);
-    dispatch_fieldEvent();
+    if (iAmHost()) dispatch_fieldEvent();
   }
 };
 


### PR DESCRIPTION
## Hva er nytt?
- Alle spillere gjør flytt med en gang i HandList og SolutionField
- CommunicationHandler aksepterer bare et flytt dersom det har gått mer enn 1 sekund siden sist moveRequest
- CommunicationListener synkroniserer alle spillerne dersom det ikke har vært flytt de siste 2 sekundene (se hearthbeat funksjonen, her fjernes også eventuelle duplikater)
- SET_LISTS_AND_FIELDS er en melding som sender både LISTS og FIELDS (i Handler og Listener)
- Din egen indikator er ikke lenger synlig for deg i SolutionField
- Lock In har fått preview lokalt
- Deselect når du trykker på den brikken du har allerede valgt