### PR TITLE
fikset alternative løsninger

### DIFF
--- a/app/src/components/state/Lobby/Lobby.js
+++ b/app/src/components/state/Lobby/Lobby.js
@@ -171,7 +171,14 @@ function Lobby({ handleClick }) {
         <div style={{ marginBottom: '1em' }}>
           <select value={selectedTaskSet} onChange={handleChange}>
             {TASKSETS.map((taskset) => (
-              <option value={taskset.number}>{taskset.label}</option>
+              <option
+                selected='true'
+                disabled='disabled'
+                hidden
+                value={taskset.number}
+              >
+                {taskset.label}
+              </option>
             ))}
           </select>
         </div>

--- a/app/src/utils/tasksets/playtest_taskset.json
+++ b/app/src/utils/tasksets/playtest_taskset.json
@@ -252,7 +252,7 @@
           "id": "3"
         },
         {
-          "code": "if num % 2 == 0:",
+          "code": "if num % 2 != 0:",
           "category": "condition",
           "indent": 2,
           "id": "4"
@@ -268,7 +268,8 @@
           "category": "function",
           "indent": 1,
           "id": "9"
-        },
+        } ],
+        [
         {
           "code": "def merge_list(list1, list2):",
           "category": "function",
@@ -322,7 +323,9 @@
           "category": "function",
           "indent": 1,
           "id": "9"
-        },
+        }
+      ],
+        [
         {
           "code": "def merge_list(list1, list2):",
           "category": "function",
@@ -390,7 +393,7 @@
     "attempts": "unlimited",
     "field": []
   },
-    {
+      {
     "codeBlocks": [
       {
         "code": "n = int(input())",
@@ -508,28 +511,298 @@
         {
           "code": "nth = n1 + n2",
           "category": "variable",
-          "indent": 3,
+          "indent": 2,
           "id": "9"
         },
         {
           "code": "n1 = n2",
           "category": "variable",
-          "indent": 3,
+          "indent": 2,
           "id": "10"
         },
         {
           "code": "n2 = nth",
           "category": "variable",
-          "indent": 3,
+          "indent": 2,
           "id": "11"
         },
         {
           "code": "count += 1",
           "category": "variable",
-          "indent": 3,
+          "indent": 2,
           "id": "12"
         }
-      ]
+      ],
+        [
+        {
+          "code": "count, n1, n2 = 0, 0, 1",
+          "category": "variable",
+          "indent": 0,
+          "id": "2"
+        },
+        {
+          "code": "n = int(input())",
+          "category": "variable",
+          "indent": 0,
+          "id": "1"
+        },
+        {
+          "code": "if n == 1:",
+          "category": "condition",
+          "indent": 0,
+          "id": "4"
+        },
+        {
+          "code": "print(n1)",
+          "category": "function",
+          "indent": 1,
+          "id": "5"
+        },
+        {
+          "code": "else:",
+          "category": "condition",
+          "indent": 0,
+          "id": "6"
+        },
+        {
+          "code": "while count < n:",
+          "category": "loop",
+          "indent": 1,
+          "id": "7"
+        },
+                {
+          "code": "count += 1",
+          "category": "variable",
+          "indent": 2,
+          "id": "12"
+        },
+        {
+          "code": "print(n1)",
+          "category": "function",
+          "indent": 2,
+          "id": "8"
+        },
+        {
+          "code": "nth = n1 + n2",
+          "category": "variable",
+          "indent": 2,
+          "id": "9"
+        },
+        {
+          "code": "n1 = n2",
+          "category": "variable",
+          "indent": 2,
+          "id": "10"
+        },
+        {
+          "code": "n2 = nth",
+          "category": "variable",
+          "indent": 2,
+          "id": "11"
+        }
+      ], [
+             {
+          "code": "count, n1, n2 = 0, 0, 1",
+          "category": "variable",
+          "indent": 0,
+          "id": "2"
+        },
+        {
+          "code": "n = int(input())",
+          "category": "variable",
+          "indent": 0,
+          "id": "1"
+        },
+        {
+          "code": "if n == 1:",
+          "category": "condition",
+          "indent": 0,
+          "id": "4"
+        },
+        {
+          "code": "print(n1)",
+          "category": "function",
+          "indent": 1,
+          "id": "5"
+        },
+        {
+          "code": "else:",
+          "category": "condition",
+          "indent": 0,
+          "id": "6"
+        },
+        {
+          "code": "while count < n:",
+          "category": "loop",
+          "indent": 1,
+          "id": "7"
+        },
+        {
+          "code": "print(n1)",
+          "category": "function",
+          "indent": 2,
+          "id": "8"
+        },
+        {
+          "code": "count += 1",
+          "category": "variable",
+          "indent": 2,
+          "id": "12"
+        },
+        {
+          "code": "nth = n1 + n2",
+          "category": "variable",
+          "indent": 2,
+          "id": "9"
+        },
+        {
+          "code": "n1 = n2",
+          "category": "variable",
+          "indent": 2,
+          "id": "10"
+        },
+        {
+          "code": "n2 = nth",
+          "category": "variable",
+          "indent": 2,
+          "id": "11"
+        }
+      ], [
+      {
+        "code": "n = int(input())",
+        "category": "variable",
+        "indent": 0,
+        "id": "1"
+      },
+      {
+        "code": "count, n1, n2 = 0, 0, 1",
+        "category": "variable",
+        "indent": 0,
+        "id": "2"
+      },
+      {
+        "code": "if n == 1:",
+        "category": "condition",
+        "indent": 0,
+        "id": "4"
+      },
+      {
+        "code": "print(n1)",
+        "category": "function",
+        "indent": 1,
+        "id": "5"
+      },
+      {
+        "code": "else:",
+        "category": "condition",
+        "indent": 0,
+        "id": "6"
+      },
+      {
+        "code": "while count < n:",
+        "category": "loop",
+        "indent": 1,
+        "id": "7"
+      },
+        {
+        "code": "count += 1",
+        "category": "variable",
+        "indent": 2,
+        "id": "12"
+      },
+      {
+        "code": "print(n1)",
+        "category": "function",
+        "indent": 2,
+        "id": "8"
+      },
+      {
+        "code": "nth = n1 + n2",
+        "category": "variable",
+        "indent": 2,
+        "id": "9"
+      },
+      {
+        "code": "n1 = n2",
+        "category": "variable",
+        "indent": 2,
+        "id": "10"
+      },
+      {
+        "code": "n2 = nth",
+        "category": "variable",
+        "indent": 2,
+        "id": "11"
+      }
+    ],
+    [
+      {
+        "code": "n = int(input())",
+        "category": "variable",
+        "indent": 0,
+        "id": "1"
+      },
+      {
+        "code": "count, n1, n2 = 0, 0, 1",
+        "category": "variable",
+        "indent": 0,
+        "id": "2"
+      },
+      {
+        "code": "if n == 1:",
+        "category": "condition",
+        "indent": 0,
+        "id": "4"
+      },
+      {
+        "code": "print(n1)",
+        "category": "function",
+        "indent": 1,
+        "id": "5"
+      },
+      {
+        "code": "else:",
+        "category": "condition",
+        "indent": 0,
+        "id": "6"
+      },
+      {
+        "code": "while count < n:",
+        "category": "loop",
+        "indent": 1,
+        "id": "7"
+      },
+      {
+        "code": "print(n1)",
+        "category": "function",
+        "indent": 2,
+        "id": "8"
+      },
+       {
+        "code": "count += 1",
+        "category": "variable",
+        "indent": 2,
+        "id": "12"
+      },
+      {
+        "code": "nth = n1 + n2",
+        "category": "variable",
+        "indent": 2,
+        "id": "9"
+      },
+      {
+        "code": "n1 = n2",
+        "category": "variable",
+        "indent": 2,
+        "id": "10"
+      },
+      {
+        "code": "n2 = nth",
+        "category": "variable",
+        "indent": 2,
+        "id": "11"
+      }
+    ]
     ],
     "description": "Create a program that asks for a positive integer n. The program then prints out the first n numbers in the fibonacci sequence. The first two numbers in the fibonacci sequence is 0 and 1. The next number is obtained by adding the preceding two terms. ",
     "hints": [
@@ -597,6 +870,64 @@
         "indent": 1,
         "id": "10"
       }
+    ],
+    "otherSolutions": [
+      [
+         {
+        "code": "def palindrome(num):",
+        "category": "function",
+        "indent": 0,
+        "id": "1"
+      },
+      {
+        "code": "original, reverse = num, 0",
+        "category": "variable",
+        "indent": 1,
+        "id": "2"
+      },
+      {
+        "code": "while num > 0:",
+        "category": "loop",
+        "indent": 1,
+        "id": "3"
+      },
+      {
+        "code": "r = num % 10",
+        "category": "variable",
+        "indent": 2,
+        "id": "4"
+      },
+      {
+        "code": "num = num // 10",
+        "category": "variable",
+        "indent": 2,
+        "id": "6"
+      },
+      {
+        "code": "reverse = (reverse * 10) + r",
+        "category": "variable",
+        "indent": 2,
+        "id": "5"
+      },
+      {
+        "code": "if original == reverse:",
+        "category": "condition",
+        "indent": 1,
+        "id": "7"
+      },
+      {
+        "code": "return True",
+        "category": "function",
+        "indent": 2,
+        "id": "8"
+      },
+      {
+        "code": "return False",
+        "category": "function",
+        "indent": 1,
+        "id": "10"
+      }
+      ]
     ],
     "distractors": [],
     "description": "Write a function to check if the given number is a palindrome number. A palindrome number is a number that is same after reverse.",


### PR DESCRIPTION
## Hva er nytt?
- Task 3 mergelist - fikset othersoloutions (dette var ikke et problem på brukertesten). Nå har det ingenting å si om man itererer list1 eller list2 først
- Task 4 fibonacci - Nå er det litt mer vilkårlig hvor count += 1 blir plassert. Count kan nå plasseres på 3 ulike steder. Først i while loop, sist i while loop og rett etter printen i while loop. Ikke helt vilkårlig ettersom det ville gitt oss 2x5x5=50 mulige løsninger (som jeg ikke gidder å lage)
- Task 5 palindrome - En alternativ løsning der num blir redusert før reverse blir regnet ut (har ikke noe å si hva som gjøres først)
- Disabled det at man kan velge task. Fikk ikke grået ut slik som du gjordet, men det er vel ikke så viktig.